### PR TITLE
Remove height from FormGroup and apply only in LinedInputGroup

### DIFF
--- a/src/docs/components/lined-input.mdx
+++ b/src/docs/components/lined-input.mdx
@@ -12,7 +12,7 @@ import { Playground, PropsTable } from 'docz';
 
 This input is awesome.
 
-<Playground className="vertical-spacing">
+<Playground>
   <LinedInputGroup
     id="name1"
     name="name1"
@@ -26,6 +26,7 @@ This input is awesome.
     value="Wrong!"
     type="email"
     errorMessage="Wrong!"
+    className="top-32"
   />
 </Playground>
 

--- a/src/lib/components/form/form-group/form-group.scss
+++ b/src/lib/components/form/form-group/form-group.scss
@@ -1,8 +1,6 @@
 @import '../../../styles/variables.scss';
 
 .form-group {
-  height: 58px;
-
   &__message {
     &--error {
       @include mini-text;

--- a/src/lib/components/form/form-group/index.js
+++ b/src/lib/components/form/form-group/index.js
@@ -8,18 +8,19 @@ const FormGroup = ({
   children,
   className,
 }) => {
-  const hassErrorMessage = !!errorMessage;
+  const hasErrorMessage = !!errorMessage;
 
   const messageClassName = classNames(
     'form-group__message',
     {
-      'form-group__message--error': hassErrorMessage,
+      'form-group__message--error': hasErrorMessage,
     },
-    className,
   );
 
+  const classes = classNames('form-group', className);
+
   return (
-    <div className="form-group">
+    <div className={classes}>
       {children}
       <span className={messageClassName}>
         {errorMessage}

--- a/src/lib/components/form/lined-input-group/__tests__/__snapshots__/lined-input-group.test.js.snap
+++ b/src/lib/components/form/lined-input-group/__tests__/__snapshots__/lined-input-group.test.js.snap
@@ -2,7 +2,39 @@
 
 exports[`LinedInputGroup renders the LinedInputGroup 1`] = `
 <div
-  className="form-group"
+  className="form-group lined-input-group"
+>
+  <div
+    className="lined-input"
+  >
+    <input
+      className="lined-input__field"
+      disabled={false}
+      id="id"
+      name="name"
+      onBlur={[MockFunction]}
+      onChange={[MockFunction]}
+      required={true}
+      type="text"
+      value="Test"
+    />
+    <label
+      className="lined-input__label"
+      htmlFor="id"
+    >
+      Name 1
+    </label>
+    <div />
+  </div>
+  <span
+    className="form-group__message"
+  />
+</div>
+`;
+
+exports[`LinedInputGroup with custom class renders the LinedInputGroup 1`] = `
+<div
+  className="form-group lined-input-group my class"
 >
   <div
     className="lined-input"

--- a/src/lib/components/form/lined-input-group/__tests__/lined-input-group.test.js
+++ b/src/lib/components/form/lined-input-group/__tests__/lined-input-group.test.js
@@ -18,4 +18,22 @@ describe('LinedInputGroup', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  describe('with custom class', () => {
+    it('renders the LinedInputGroup', () => {
+      const component = renderer.create(
+        <LinedInputGroup
+          id="id"
+          name="name"
+          label="Name 1"
+          value="Test"
+          onChange={jest.fn()}
+          onBlur={jest.fn()}
+          className="my class"
+        />,
+      );
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/lib/components/form/lined-input-group/index.js
+++ b/src/lib/components/form/lined-input-group/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import FormGroup from '../form-group';
 import LinedInput from '../lined-input';
+import './lined-input-group.scss';
 
 const LinedInputGroup = ({
   fieldRef,
@@ -17,9 +19,10 @@ const LinedInputGroup = ({
   className,
 }) => {
   const hasError = !!errorMessage;
+  const classes = classNames('lined-input-group', className);
 
   return (
-    <FormGroup errorMessage={errorMessage} className={className}>
+    <FormGroup errorMessage={errorMessage} className={classes}>
       <LinedInput
         fieldRef={fieldRef}
         id={id}

--- a/src/lib/components/form/lined-input-group/lined-input-group.scss
+++ b/src/lib/components/form/lined-input-group/lined-input-group.scss
@@ -1,0 +1,5 @@
+@import '../../../styles/variables';
+
+.lined-input-group {
+  height: $space-48;
+}

--- a/src/test-helpers/controlleds/lined-input.js
+++ b/src/test-helpers/controlleds/lined-input.js
@@ -15,7 +15,7 @@ class SimpleForm extends Component {
   render() {
     const { value } = this.state;
     const {
-      id, name, label, errorMessage, type,
+      id, name, label, errorMessage, type, className,
     } = this.props;
 
     return (
@@ -27,6 +27,7 @@ class SimpleForm extends Component {
         type={type}
         errorMessage={errorMessage}
         onChange={this.onChangeName}
+        className={className}
       />
     );
   }


### PR DESCRIPTION
- Remoção do `height` do FormGroup genérico
- Aplicação do `height` apenas no LinedInputGroup por causa do floating label