### PR TITLE
Add more menu link states

### DIFF
--- a/src/docs/components/menu.mdx
+++ b/src/docs/components/menu.mdx
@@ -4,16 +4,20 @@ menu: Components
 route: /components/menu
 ---
 
-import { Menu } from '../../lib';
+import Link from '../../lib/components/menu/link';
 import { Playground } from 'docz';
 
 # Menu Component
 
 This is the menu component.
 
-## Playground
+## Links
 
 <Playground>
-  <Menu></Menu>
+  <div><Link>Link</Link></div>
+  <div><Link active>Link Active</Link></div>
+  <div><Link url="/">Link with URL</Link></div>
+  <div><Link child>Link Child</Link></div>
+  <div><Link child active>Link Child Active</Link></div>
 </Playground>
 

--- a/src/lib/components/menu/index.js
+++ b/src/lib/components/menu/index.js
@@ -3,12 +3,11 @@ import Link from './link';
 
 const Menu = () => (
   <div>
-    <div>
-      <Link>Link 1</Link>
-    </div>
-    <div>
-      <Link url="/">Link 2</Link>
-    </div>
+    <div><Link>Link</Link></div>
+    <div><Link active>Link Active</Link></div>
+    <div><Link url="/">Link with URL</Link></div>
+    <div><Link child>Link Child</Link></div>
+    <div><Link child active>Link Child Active</Link></div>
   </div>
 );
 

--- a/src/lib/components/menu/index.js
+++ b/src/lib/components/menu/index.js
@@ -1,14 +1,6 @@
 import React from 'react';
 import Link from './link';
 
-const Menu = () => (
-  <div>
-    <div><Link>Link</Link></div>
-    <div><Link active>Link Active</Link></div>
-    <div><Link url="/">Link with URL</Link></div>
-    <div><Link child>Link Child</Link></div>
-    <div><Link child active>Link Child Active</Link></div>
-  </div>
-);
+const Menu = () => null;
 
 export default Menu;

--- a/src/lib/components/menu/index.js
+++ b/src/lib/components/menu/index.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import Link from './link';
+// import React from 'react';
+// import Link from './link';
 
 const Menu = () => null;
 

--- a/src/lib/components/menu/link/__tests__/__snapshots__/link.test.js.snap
+++ b/src/lib/components/menu/link/__tests__/__snapshots__/link.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Link with modifiers with active and child truthy 1`] = `
+<span
+  className="menu__link menu__link--child"
+>
+  test
+</span>
+`;
+
+exports[`Link with modifiers with active truthy 1`] = `
+<span
+  className="menu__link menu__link--active"
+>
+  test
+</span>
+`;
+
+exports[`Link with modifiers with child truthy 1`] = `
+<span
+  className="menu__link menu__link--child"
+>
+  test
+</span>
+`;
+
 exports[`Link with url should render link with href 1`] = `
 <a
   className="menu__link"

--- a/src/lib/components/menu/link/__tests__/link.test.js
+++ b/src/lib/components/menu/link/__tests__/link.test.js
@@ -24,4 +24,24 @@ describe('Link', () => {
       expect(tree).toMatchSnapshot();
     });
   });
+
+  describe('with modifiers', () => {
+    it('with active truthy', () => {
+      const component = renderer.create(<Link active>test</Link>);
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('with child truthy', () => {
+      const component = renderer.create(<Link child>test</Link>);
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('with active and child truthy', () => {
+      const component = renderer.create(<Link child>test</Link>);
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/lib/components/menu/link/index.js
+++ b/src/lib/components/menu/link/index.js
@@ -1,23 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import './link.scss';
 
-const Link = ({ url, target, children }) => (
-  url ? (
-    <a href={url} target={target} className="menu__link">{children}</a>
-  ) : (
-    <span className="menu__link">{children}</span>
-  )
-);
+const Link = ({
+  url,
+  child,
+  active,
+  target,
+  children,
+}) => {
+  const className = classNames(
+    'menu__link',
+    { 'menu__link--child': child, 'menu__link--active': active },
+  );
+
+  return (
+    url ? (
+      <a href={url} target={target} className={className}>{children}</a>
+    ) : (
+      <span className={className}>{children}</span>
+    )
+  );
+};
 
 Link.defaultProps = {
-  target: '_self',
   url: null,
+  child: false,
+  active: false,
+  target: '_self',
 };
 
 Link.propTypes = {
   children: PropTypes.node.isRequired,
   url: PropTypes.string,
+  child: PropTypes.bool,
+  active: PropTypes.bool,
   target: PropTypes.oneOf([
     '_blank',
     '_parent',

--- a/src/lib/components/menu/link/link.scss
+++ b/src/lib/components/menu/link/link.scss
@@ -13,9 +13,13 @@
     color: $neutral;
   }
 
-  &:active {
+  &--active {
     @include small-text(bold);
+  }
 
-    color: $brand;
+  &--child {
+    &.menu__link--active {
+      color: $brand;
+    }
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6332116/53499124-81401500-3a86-11e9-8a31-f5c65989ebf0.png)

Add two modifiers:
- `--active`: when link is the actual page
- `--child`: when link is child, inner of dropdown

The combination of these two modifiers is covered two as specified on Figma.