### PR TITLE
Support for pass ref in Button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4617,6 +4617,14 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
     },
+    "circular-std": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/circular-std/-/circular-std-1.0.0.tgz",
+      "integrity": "sha512-nQNaCF4B3LrsTD2ZJX5ttsr+ARrIF1OXP9KIzoXcVriyE1WpIZuowpYVk1dUVdoexNEJgyVnX6jCBqO/xxoIzw==",
+      "requires": {
+        "less": "3.9.0"
+      }
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4698,6 +4706,11 @@
         "strip-ansi": "3.0.1",
         "wrap-ansi": "2.1.0"
       }
+    },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "0.2.4",
@@ -11097,7 +11110,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-      "dev": true,
       "requires": {
         "react-is": "16.8.6"
       }
@@ -11643,6 +11655,12 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+    },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "optional": true
     },
     "immer": {
       "version": "1.10.0",
@@ -13720,6 +13738,45 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+    },
+    "less": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.9.0.tgz",
+      "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
+      "requires": {
+        "clone": "2.1.2",
+        "errno": "0.1.7",
+        "graceful-fs": "4.1.15",
+        "image-size": "0.5.5",
+        "mime": "1.6.0",
+        "mkdirp": "0.5.1",
+        "promise": "7.3.1",
+        "request": "2.88.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "optional": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "optional": true,
+          "requires": {
+            "asap": "2.0.6"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        }
+      }
     },
     "leven": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "classnames": "^2.2.6",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
+    "hoist-non-react-statics": "^3.3.0",
     "node-sass": "^4.11.0",
     "prop-types": "^15.6.2",
     "ramda": "^0.26.1",

--- a/src/lib/components/button/__tests__/button.test.js
+++ b/src/lib/components/button/__tests__/button.test.js
@@ -17,6 +17,19 @@ describe('Button', () => {
       expect(tree).toMatchSnapshot();
     });
 
+    describe('with ref', () => {
+      it('should populate ref', () => {
+        const node = {};
+        const ref = React.createRef();
+
+        renderer.create(<Button ref={ref}>Test</Button>, {
+          createNodeMock: () => node,
+        });
+
+        expect(ref.current).toBe(node);
+      });
+    });
+
     describe('with modifier', () => {
       describe('primary', () => {
         it('should render button properly', () => {

--- a/src/lib/components/button/index.js
+++ b/src/lib/components/button/index.js
@@ -2,9 +2,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
+import withForwardedRef from '../withForwardedRef';
+
 import './button.scss';
 
 const Button = ({
+  forwardedRef,
   children,
   className,
   type,
@@ -31,17 +35,19 @@ const Button = ({
 
   return (
     <button
+      ref={forwardedRef}
       type={type}
       className={classes}
       disabled={disabled}
       onClick={onClick}
     >
-      { children }
+      {children}
     </button>
   );
 };
 
 Button.defaultProps = {
+  forwardedRef: undefined,
   type: 'button',
   className: null,
   primary: false,
@@ -55,6 +61,9 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
+  forwardedRef: PropTypes.shape({
+    current: PropTypes.any,
+  }),
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
@@ -68,4 +77,4 @@ Button.propTypes = {
   onClick: PropTypes.func,
 };
 
-export default Button;
+export default withForwardedRef(Button);

--- a/src/lib/components/withForwardedRef.js
+++ b/src/lib/components/withForwardedRef.js
@@ -1,0 +1,11 @@
+import React, { forwardRef } from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+
+const withForwardedRef = Component => hoistNonReactStatics(
+  forwardRef((props, ref) => (
+    <Component forwardedRef={ref} {...props} />
+  )),
+  Component,
+);
+
+export default withForwardedRef;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5509,6 +5509,13 @@ hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"


### PR DESCRIPTION
Problema:

- No [PR - Feature/events and reasons comparable](https://github.com/indeva/web/pull/984) surgiu a necessidade de usar a ref do `button` do `DOM` para descobrir se o usuario clicava em algum elemento da tela que nao fosse o botao em especifico. Isso serve para o comportamento do dropdown: se voce abrir um dropdown, se clicar em algum elemento que nao seja o proprio `dropdown` ou o botao que abriu o dropdown, o dropdown deve fechar.

Resolucao:

- Para isso foi adicionado o suporte a `ref` ao `Button`, em geral, TODO COMPONENTE que esta publicado e vai ser consumido por outro sistema, deveria possuir suporte para `ref` e `className` (se for um componente visual). A ideia eh que se a gente esta abstraindo um elemento nativo do DOM, ao menos, comportamentos nativos do componente como eventos, ref, className e as propriedades nativas, ou sejam disponiveis de controle por quem usa nosso componente customizado, ou nos controlamos essas coisas dentro do componente.