### PR TITLE
Add new font awesome icon to use in new menu forms item

### DIFF
--- a/src/lib/icons.js
+++ b/src/lib/icons.js
@@ -7,6 +7,7 @@ import { faAnalytics as farAnalytics } from '@fortawesome/pro-regular-svg-icons/
 import { faCheckCircle as farCheckCircle } from '@fortawesome/pro-regular-svg-icons/faCheckCircle';
 import { faChevronDown as farChevronDown } from '@fortawesome/pro-regular-svg-icons/faChevronDown';
 import { faCommentAltLines as farCommentAltLines } from '@fortawesome/pro-regular-svg-icons/faCommentAltLines';
+import { faEnvelopeOpenText as farEnvelopeOpenText } from '@fortawesome/pro-regular-svg-icons/faEnvelopeOpenText';
 import { faFilter as farFilter } from '@fortawesome/pro-regular-svg-icons/faFilter';
 import { faFolderOpen as farFolderOpen } from '@fortawesome/pro-regular-svg-icons/faFolderOpen';
 import { faLightbulb as farLightbulb } from '@fortawesome/pro-regular-svg-icons/faLightbulb';
@@ -28,6 +29,7 @@ library.add(
   farCheckCircle,
   farChevronDown,
   farCommentAltLines,
+  farEnvelopeOpenText,
   farFilter,
   farFolderOpen,
   farLightbulb,


### PR DESCRIPTION
## Fonte

CARD: https://app.pipefy.com/pipes/644698#cards/38815667 - Criar item do menu com flipper

## Problema

Disponibilizar o ícone para ser usado no novo menu `Formulários`

![forms-icon](https://user-images.githubusercontent.com/1884461/64568031-12465180-d330-11e9-914a-a4775751cd5b.png)
